### PR TITLE
Also save image width/height on original image if possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,15 +184,20 @@ ImageWrangler.prototype.process = function(ctx) {
 				// console.log(part.headers["content-type"]);
 
 				if (!err) {
-					var ft = fileType(stream);
-					wrangler.uploadFile(ctx, {
+					var file = {
 						task: task,
 						originalFilename: part.filename,
 						originalPath: subDirPath,
 						filename: '/' + subDirPath + '/' + outputName,
-						mime: ft.mime,
 						sizes: sizeOf(stream)
-					}, stream, next);
+					};
+					var ft = fileType(stream);
+					if (ft && ft.mime !== null) {
+						file.mime = ft.mime;
+					}
+
+					wrangler.uploadFile(ctx, file, stream, next);
+
 				} else {
 					//console.log(' error writing: ' + err);
 					ctx.done(err);

--- a/index.js
+++ b/index.js
@@ -281,16 +281,11 @@ ImageWrangler.prototype.process = function(ctx) {
 
 		function uploadOriginalFile(path) {
 			readPromise.then(function(buffer){
-				var sizes = {width: 0, height: 0};
-				var ext = path.substring(path.lastIndexOf('.') + 1);
-				if ((ext && ext.length > 0) && (ext === 'png' || ext === 'jpg' || ext === 'gif' || ext === 'svg')) {
-					sizes = sizeOf(buffer);
-				}
+				// var ft = fileType(buffer);
 				wrangler.uploadFile(ctx, {
 					originalFilename: part.filename,
 					originalPath: subDirPath,
 					filename: path,
-					sizes: sizes,
 					mime: part.headers["content-type"]
 				}, buffer, function(task, savedFile) {
 					var size = task ? task.suffix : "original";

--- a/index.js
+++ b/index.js
@@ -281,11 +281,16 @@ ImageWrangler.prototype.process = function(ctx) {
 
 		function uploadOriginalFile(path) {
 			readPromise.then(function(buffer){
-				// var ft = fileType(buffer);
+				var sizes = {width: 0, height: 0};
+				var ext = path.substring(path.lastIndexOf('.') + 1);
+				if ((ext && ext.length > 0) && (ext === 'png' || ext === 'jpg' || ext === 'gif' || ext === 'svg')) {
+					sizes = sizeOf(buffer);
+				}
 				wrangler.uploadFile(ctx, {
 					originalFilename: part.filename,
 					originalPath: subDirPath,
 					filename: path,
+					sizes: sizes,
 					mime: part.headers["content-type"]
 				}, buffer, function(task, savedFile) {
 					var size = task ? task.suffix : "original";


### PR DESCRIPTION
This saves width/height on normal web compatible images like PNG/JPG/GIF/SVG but not for EPS etc.
